### PR TITLE
expected: Allow move-only unexpected type

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ expected: Allows to move-assign from expected, error
 expected: Allows to forward-assign from value
 expected: Allows to copy-assign from unexpected
 expected: Allows to move-assign from unexpected
+expected: Allows to move-assign from move-only unexpected
 expected: Allows to emplace value
 expected: Allows to emplace value from initializer_list
 expected: Allows to be swapped

--- a/include/nonstd/expected.hpp
+++ b/include/nonstd/expected.hpp
@@ -1664,10 +1664,11 @@ public:
         return *this;
     }
 
-    template< typename G
+    template< typename G = E
         nsel_REQUIRES_T(
-            std::is_copy_constructible<E>::value    // TODO: std::is_nothrow_copy_constructible<E>
-            && std::is_copy_assignable<E>::value
+            std::is_constructible<E, G const&>::value &&
+            std::is_copy_constructible<G>::value    // TODO: std::is_nothrow_copy_constructible<G>
+            && std::is_copy_assignable<G>::value
         )
     >
     expected & operator=( nonstd::unexpected_type<G> const & error )
@@ -1676,10 +1677,11 @@ public:
         return *this;
     }
 
-    template< typename G
+    template< typename G = E
         nsel_REQUIRES_T(
-            std::is_move_constructible<E>::value    // TODO: std::is_nothrow_move_constructible<E>
-            && std::is_move_assignable<E>::value
+            std::is_constructible<E, G&&>::value &&
+            std::is_move_constructible<G>::value    // TODO: std::is_nothrow_move_constructible<G>
+            && std::is_move_assignable<G>::value
         )
     >
     expected & operator=( nonstd::unexpected_type<G> && error )


### PR DESCRIPTION
Fix concept checks in the assignment operators.

Using a move-only unexpected type resulted in a hard error when trying to instantiate `expected`, because the concept check was referring to the class template parameter `E`, not the assignment operator template parameter `G`, so in the context of `operator=`, it was not a dependent type. 