### PR TITLE
Fix r-value ref miscompile on MSVC v19.22.

### DIFF
--- a/include/nonstd/expected.hpp
+++ b/include/nonstd/expected.hpp
@@ -1769,12 +1769,14 @@ public:
 
     constexpr value_type const && operator *() const &&
     {
-        return assert( has_value() ), std::move( contained.value() );
+        assert( has_value() );
+        return std::move( contained.value() );
     }
 
     nsel_constexpr14 value_type && operator *() &&
     {
-        return assert( has_value() ), std::move( contained.value() );
+        assert( has_value() );
+        return std::move( contained.value() );
     }
 
 #endif
@@ -1835,12 +1837,14 @@ public:
 
     constexpr error_type const && error() const &&
     {
-        return assert( ! has_value() ), std::move( contained.error() );
+        assert( ! has_value() );
+        return std::move( contained.error() );
     }
 
     error_type && error() &&
     {
-        return assert( ! has_value() ), std::move( contained.error() );
+        assert( ! has_value() );
+        return std::move( contained.error() );
     }
 
 #endif
@@ -2107,12 +2111,14 @@ public:
 
     constexpr error_type const && error() const &&
     {
-        return assert( ! has_value() ), std::move( contained.error() );
+        assert( ! has_value() );
+        return std::move( contained.error() );
     }
 
     error_type && error() &&
     {
-        return assert( ! has_value() ), std::move( contained.error() );
+        assert( ! has_value() );
+        return std::move( contained.error() );
     }
 
 #endif

--- a/include/nonstd/expected.hpp
+++ b/include/nonstd/expected.hpp
@@ -1769,14 +1769,12 @@ public:
 
     constexpr value_type const && operator *() const &&
     {
-        assert( has_value() );
-        return std::move( contained.value() );
+        return std::move( ( assert( has_value() ), contained.value() ) );
     }
 
     nsel_constexpr14 value_type && operator *() &&
     {
-        assert( has_value() );
-        return std::move( contained.value() );
+        return std::move( ( assert( has_value() ), contained.value() ) );
     }
 
 #endif
@@ -1837,14 +1835,12 @@ public:
 
     constexpr error_type const && error() const &&
     {
-        assert( ! has_value() );
-        return std::move( contained.error() );
+        return std::move( ( assert( ! has_value() ), contained.error() ) );
     }
 
     error_type && error() &&
     {
-        assert( ! has_value() );
-        return std::move( contained.error() );
+        return std::move( ( assert( ! has_value() ), contained.error() ) );
     }
 
 #endif
@@ -2111,14 +2107,12 @@ public:
 
     constexpr error_type const && error() const &&
     {
-        assert( ! has_value() );
-        return std::move( contained.error() );
+        return std::move( ( assert( ! has_value() ), contained.error() ) );
     }
 
     error_type && error() &&
     {
-        assert( ! has_value() );
-        return std::move( contained.error() );
+        return std::move( ( assert( ! has_value() ), contained.error() ) );
     }
 
 #endif

--- a/test/expected.t.cpp
+++ b/test/expected.t.cpp
@@ -1804,6 +1804,16 @@ nonstd::expected< MyNonCopyableObject, Error > create_moveable()
 
 } // namespace issue_32
 
+CASE( "pr-41" )
+{
+    expected<int, int> a{7};
+    expected<int, int> b{unexpect, 7};
+    expected<void, int> c{unexpect, 7};
+    EXPECT( *std::move(a) == 7 );
+    EXPECT( std::move(b).error() == 7 );
+    EXPECT( std::move(c).error() == 7 );
+}
+
 // -----------------------------------------------------------------------
 //  using as optional
 

--- a/test/expected.t.cpp
+++ b/test/expected.t.cpp
@@ -1807,11 +1807,17 @@ nonstd::expected< MyNonCopyableObject, Error > create_moveable()
 CASE( "pr-41" )
 {
     expected<int, int> a{7};
+    const expected<int, int> ca{7};
     expected<int, int> b{unexpect, 7};
+    const expected<int, int> cb{unexpect, 7};
     expected<void, int> c{unexpect, 7};
+    const expected<void, int> cc{unexpect, 7};
     EXPECT( *std::move(a) == 7 );
+    EXPECT( *std::move(ca) == 7 );
     EXPECT( std::move(b).error() == 7 );
+    EXPECT( std::move(cb).error() == 7 );
     EXPECT( std::move(c).error() == 7 );
+    EXPECT( std::move(cc).error() == 7 );
 }
 
 // -----------------------------------------------------------------------


### PR DESCRIPTION
Returning an r-value reference through the comma operator is miscompiled by MSVC v19.22, as evidenced [here](https://godbolt.org/#z:OYLghAFBqd5TKALEBjA9gEwKYFFMCWALugE4A0BIEAZgQDbYB2AhgLbYgDkAjF%2BTXRMiAZVQtGIHgBYBQogFUAztgAKAD24AGfgCsp5eiyahUAUgBMAIUtXyKxqiIEh1ZpgDC6egFc2TA3cAGQImbAA5PwAjbFIQAE5yAAd0JWIXJi9ffwMUtOchELDIthi4xIdsJwyRIhZSIiy/AJ57bEcCplr6oiKI6NiE%2BzqGppzWpRHe0P7SwfiASnt0H1JUTi5QoksANl2AaiJsSZ4ILd2D9QX9swB2Gy0AQX2X/cmWZ1QAfXFJswBmDwAN3QBEwANwEC0CwBD2er1I2CIqyYbzqnx%2BLD%2BgPOFj2eIhECusLMTzuABFSY8qbj8TtDsciBYzsILnj9lcbvcqa99ojkaRUe8Mb9toCQWDCdDyGiPgRvqKAR5aRd/pDif84RSqVwlvRuABWfgBLg6cjobgeWy2N4rNbYG4Wf58chEbS6pYAaxABq0hm40n4bB9fpNZotXH4ShAfrdpt15DgsBQKyISR8REo1AwbCSDEGrWwhBIcVagmEYgknBkcmEyjUmnjrsRGxdAHdSCwktw%2BHrDcb3ebuAB5DPpoj7dA0Dk7aT7NhKIGofZAnjxAB0Fgs%2BwgXlz%2BdIjudC34cZ0CyWSGwLBwcQgfa4gfIwd95DD/AjUZjrvdF/I3tffUuH%2BAcm0/H94yWJMEHgCAUBzPNGAoKgIAQg8QCXJIki%2BVd4i%2BLcvnUWcBAYI5SGjCAokHKJQnqABPHt%2BBzDhhGHJh6AYpscDYYxgEkLiCERaogWOQdsHUKoM1bfgtnaQd6AIKJO1IOivBwQciFIAhg14BMaCMYAlAANQIbA22HJJmEY2tRHESQa3LRQVA0Qd9FaIwTDQa1rEMRTo0gJZ0CSTpowAemHCZ2iqTo3CYTxvGaQI4r6EoylyVJ0iEMYWmSDLOhSgZSzaDoaimbKDEqaohG6BoCrmIr3lGBLxmGHo6rSngliUO11gMTTsGkh8jTfQcIyIucFyXFc103bdd28ux9nwYgyCPVp9j3RDYjWk8IPPS9r1vagHyfF9Q1G7gv1jX9E0QOC0HQfckKzVDHq2uJMOw3D8P%2BQjiLoegyIoqimxo1gVOs5jmCINiOMHbjeP4s1CCE5wROjJtxMko5rNkoCzQUpT6LUjYzU07TGKWfSWEMkyzIsqzdJsyt7NkRz6xcpt9AsQxeK86xbF8qJ/Pvc1goyMKIuK6KMli%2BLshy4IZlSgtcvyDJytaPJMqYdrVcqzoasaZqcoN0q2uVwqKrKk3rYt4orc65ZVl61p%2BsG/0uGG98hy4cb50XZdcM3f4dytAWfKW4tVssZ0ZU2g8jwsXazw9cgrxvQZRYAv0gNOkMRrAy77G/VO/xzz2QML8Ni7Lh8LFAmvIz2tORPI2XpCAA%3D%3D).

Examples of tests failures without the `expected.hpp` changes on MSVC v19.16:
```
expected-lite\test\expected.t.cpp(1812): failed: pr-41: *std::move(a) == 7 for -858993460 == 7
expected-lite\test\expected.t.cpp(1813): failed: pr-41: std::move(b).error() == 7 for -858993460 == 7
expected-lite\test\expected.t.cpp(1814): failed: pr-41: std::move(c).error() == 7 for -858993460 == 7
```