### PR TITLE
bump minor version number for release 0.6.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ cmake_minimum_required( VERSION 3.5 FATAL_ERROR )
 
 project(
     expected_lite
-    VERSION 0.5.0
+    VERSION 0.6.0
 #   DESCRIPTION "Expected objects in C++11 and later in a single-file header-only library"
 #   HOMEPAGE_URL "https://github.com/martinmoene/expected-lite"
     LANGUAGES CXX )

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,7 +1,7 @@
 from conans import ConanFile, CMake
 
 class ExpectedLiteConan(ConanFile):
-    version = "0.5.0"
+    version = "0.6.0"
     name = "expected-lite"
     description = "Expected objects for C++11 and later"
     license = "Boost Software License - Version 1.0. http://www.boost.org/LICENSE_1_0.txt"

--- a/include/nonstd/expected.hpp
+++ b/include/nonstd/expected.hpp
@@ -13,7 +13,7 @@
 #define NONSTD_EXPECTED_LITE_HPP
 
 #define expected_lite_MAJOR  0
-#define expected_lite_MINOR  5
+#define expected_lite_MINOR  6
 #define expected_lite_PATCH  0
 
 #define expected_lite_VERSION  expected_STRINGIFY(expected_lite_MAJOR) "." expected_STRINGIFY(expected_lite_MINOR) "." expected_STRINGIFY(expected_lite_PATCH)


### PR DESCRIPTION
Commit b78dd92cc92b0cfe4eedad823cfd411c13afeb66 was tagged as [v0.6.0](https://github.com/martinmoene/expected-lite/releases/tag/v0.6.0), but the version number has not been increased in code.