### PR TITLE
Do not cancel all jobs in a workflow if one fails.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   gcc:
     strategy:
+      fail-fast: false
       matrix:
         version: [9, 10, 11]
 
@@ -44,6 +45,7 @@ jobs:
 
   clang:
     strategy:
+      fail-fast: false
       matrix:
         version: [11, 12]
 
@@ -74,6 +76,7 @@ jobs:
 
   msvc:
     strategy:
+      fail-fast: false
       matrix:
         os: [windows-2019, windows-2022]
 
@@ -94,4 +97,3 @@ jobs:
       - name: Run tests
         working-directory: build
         run: ctest -C Release --output-on-failure -j 4
-


### PR DESCRIPTION
See <https://github.com/martinmoene/nonstd-lite-project/issues/71>.