### PR TITLE
monadic operations: fix disable

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Define this macro to 1 to experience the by-design compile-time errors of the li
 
 By default, *expected lite* provides monadic operations as described in [P2505R5](http://wg21.link/p2505r5). You can disable these operations by defining the following macro.
 
--D<b>nsel\_P2505R</b>=
+-D<b>nsel\_P2505R</b>=0
 
 You can use the R3 revision of P2505, which lacks `error_or`, and uses `remove_cvref` for transforms, by defining the following macro.
 

--- a/test/expected.t.cpp
+++ b/test/expected.t.cpp
@@ -2171,6 +2171,7 @@ CASE( "issue-58" )
     EXPECT( !unexpected.has_value() );
 }
 
+#if nsel_P2505R >= 3
 CASE( "invoke" )
 {
     struct A {
@@ -2197,6 +2198,7 @@ CASE( "invoke" )
     EXPECT( nonstd::expected_lite::detail::invoke(&A::get2, ref, 'a') == 12 );
     EXPECT( nonstd::expected_lite::detail::invoke(&A::get2, cref, 'a') == 7 );
 }
+#endif // nsel_P2505R >= 3
 
 // -----------------------------------------------------------------------
 //  using as optional


### PR DESCRIPTION
When compiling with `-DCMAKE_CXX_FLAGS=-Dnsel_P2505R=`, as documented in the README to disable P2505 support, the macro expansions resulted in an empty string, leading to errors like this on all expansions:
```
/home/szaszm/expected-lite/test/expected.t.cpp:1243:17: error: operator '>=' has no left operand
 1243 | #if nsel_P2505R >= 4
      |                 ^~
```

This fixes that by changing the version checks to use `(nsel_P2505R+0)`. Since R0 is not implemented, and this results in an expansion to `(+0)` in the case of an empty `nsel_P2505R` macro, and disabling the feature.

Also adds missing `#if` blocks around the `invoke` test. related error:
```
/home/szaszm/expected-lite/test/expected.t.cpp:2181:51: error: ‘invoke’ is not a member of ‘nonstd::expected_lite::detail’
 2181 |     static_assert( nonstd::expected_lite::detail::invoke( &A::x, A{21} ) == 21, "" );
```


Alternatively, we could assign the value `-1` (or anything less than 3) to disabled in the README, which would not need the `(+0)` workaround. Just write a comment if you prefer that, and I can quickly update the pull request.