### PR TITLE
Update expected.hpp

### DIFF
--- a/include/nonstd/expected.hpp
+++ b/include/nonstd/expected.hpp
@@ -276,7 +276,7 @@ namespace nonstd {
 #include <utility>
 
 // additional includes:
-
+#define WIN32_LEAN_AND_MEAN
 #if nsel_CONFIG_NO_EXCEPTIONS
 # if nsel_CONFIG_NO_EXCEPTIONS_SEH
 #  include <windows.h>   // for ExceptionCodes


### PR DESCRIPTION
Title: Add WIN32_LEAN_AND_MEAN Macro to Resolve Naming Conflicts

Body:

Problem Description
While compiling the Cesium project, I encountered naming conflicts due to the absence of the WIN32_LEAN_AND_MEAN macro definition. This macro directs Windows headers to include only the essential parts, helping to avoid potential naming conflicts and possibly reducing compilation time.

Proposed Change
I suggest adding the WIN32_LEAN_AND_MEAN macro definition to the project to address and prevent potential naming conflicts and to optimize the compilation process. To maintain flexibility and backward compatibility, I propose making this macro a configurable compile option, allowing users to enable or disable it based on their needs.

Implementation Details
Add the following code to the project's main header file or an appropriate configuration file:

```
#ifndef WIN32_LEAN_AND_MEAN
#define WIN32_LEAN_AND_MEAN
#endif

```

Additionally, document how to enable or disable this macro depending on the user's compilation environment.

Expected Impact
Integrating this macro should reduce potential naming conflicts caused by the full inclusion of the Windows API and might slightly improve compilation efficiency. This change is expected to have no impact on existing functionalities and has been confirmed not to introduce new issues through CI testing.

Request for Feedback
I invite feedback from other community members and project maintainers, especially regarding the compatibility and effectiveness of this change in different environments. Any suggestions on how to better integrate this change are highly welcome.

Conclusion
Thank you for your time and consideration! I look forward to your feedback and hope that this change will bring practical benefits to the project.