### PR TITLE
Fix some Clang warnings

### DIFF
--- a/include/nonstd/expected.hpp
+++ b/include/nonstd/expected.hpp
@@ -2330,7 +2330,7 @@ public:
     template< typename Ex >
     bool has_exception() const
     {
-        using ContainedEx = typename std::remove_reference< decltype( get_unexpected().value() ) >::type;
+        using ContainedEx = typename std::remove_reference< decltype( get_unexpected().error() ) >::type;
         return ! has_value() && std::is_base_of< Ex, ContainedEx>::value;
     }
 
@@ -2912,7 +2912,7 @@ public:
     template< typename Ex >
     bool has_exception() const
     {
-        using ContainedEx = typename std::remove_reference< decltype( get_unexpected().value() ) >::type;
+        using ContainedEx = typename std::remove_reference< decltype( get_unexpected().error() ) >::type;
         return ! has_value() && std::is_base_of< Ex, ContainedEx>::value;
     }
 

--- a/test/expected.t.cpp
+++ b/test/expected.t.cpp
@@ -607,7 +607,7 @@ CASE( "make_unexpected_from_current_exception(): Allows to create an unexpected_
 CASE( "unexpected: C++17 and later provide unexpected_type as unexpected" )
 {
 #if nsel_CPP17_OR_GREATER || nsel_COMPILER_MSVC_VERSION > 141
-    nonstd::unexpected<int> u{7};
+    [[maybe_unused]] nonstd::unexpected<int> u{7};
 #else
     EXPECT( !!"unexpected is not available (no C++17)." );
 #endif
@@ -2281,7 +2281,7 @@ CASE( "invoke" )
 
 struct nullopt_t{};
 
-const nullopt_t nullopt{};
+[[maybe_unused]] const nullopt_t nullopt{};
 
 /// optional expressed in expected
 


### PR DESCRIPTION
A plain `cmake .. ; make` on OSX with the stock Clang gives some warnings that look easy to fix; so, I fixed them.

The second commit, re `decltype( get_unexpected().value() )`, merits a close look, because the old code seems so weird (your code using a method that you yourself deprecated). There might be something sneaky going on there.