### PR TITLE
Mark expected as [[nodiscard]]

### DIFF
--- a/include/nonstd/expected.hpp
+++ b/include/nonstd/expected.hpp
@@ -1824,10 +1824,10 @@ namespace expected_lite {
 
 #if nsel_P0323R <= 2
 template< typename T, typename E = std::exception_ptr >
-class expected
+class [[nodiscard]] expected
 #else
 template< typename T, typename E >
-class expected
+class [[nodiscard]] expected
 #endif // nsel_P0323R
 {
 private:


### PR DESCRIPTION
Since it holds either a result or an error (that is, it always might hold an error), an `expected` return value should never be blindly discarded.

At least that's my take on it: https://quuxplusone.github.io/blog/2024/12/08/should-expected-be-nodiscard/

`boost::outcome_v2::result<T>` and `llvm::Expected<T>` are already marked nodiscard. No vendor's `std::expected` is marked _yet_, but the /r/cpp chatter re my above post makes it sound like both STL and jwakely are at least considering it now.

IMHO this is a Very Good Idea, but if you as the project owner think it's not (or not yet), then feel free to close it.