### PR TITLE
Fix failing Clang builds on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [11, 12]
+        include:
+          - version: 11
+            os: 'ubuntu-22.04'
+          - version: 12
+            os: 'ubuntu-22.04'
+          - version: 16
+            os: 'ubuntu-24.04'
+          - version: 19
+            os: 'ubuntu-24.04'
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
A while ago the `ubuntu-latest` image moved from Ubuntu 22.04 to Ubuntu 24.04. See <https://github.com/actions/runner-images/issues/10636>. However, Ubuntu 24.04 does not have packages for Clang 11 and 12 anymore, thus the Clang jobs failed when they tried to install the corresponding compilers. Therefore, the workflow is changed to use `ubuntu-22.04` instead of `ubuntu-latest` for Clang 11 and Clang 12.

Furthermore, jobs for Clang 16 - the first major version of Clang to support `std::expected` - and Clang 19 (latest Clang version available on Ubuntu 24.04) are added.

The reason for those additions is basically <https://github.com/martinmoene/nonstd-lite-project/issues/75>. Since Clang 11 and 12 do not support `std::excepted`, there should also be some tests with Clang versions that do. Clang 16 is the obvious choice here, because it is the first Clang version that comes with built-in support for `std::expected`. Clang 19 is just the latest Clang currently available via Ubuntu package respositories. I think that is a good choice to catch potential problems with the latest Clang.