### PR TITLE
Fix failing MSVC build on GitHub Actions

### DIFF
--- a/test/expected.t.cpp
+++ b/test/expected.t.cpp
@@ -9,6 +9,7 @@
 //   A proposal to add a utility class to represent expected monad
 //   by Vicente J. Botet Escriba and Pierre Talbot, http:://wg21.link/p0323
 
+#include <cassert>
 #include "expected-main.t.hpp"
 
 #ifndef nsel_CONFIG_CONFIRMS_COMPILATION_ERRORS


### PR DESCRIPTION
Fixes the build failure with MSVC on Windows 2022.

See <https://github.com/martinmoene/expected-lite/actions/runs/13823506911/job/38673977228?pr=79> for the failure. Boils down to:

```
D:\a\expected-lite\expected-lite\test\expected.t.cpp(2245,13): error C3861: 'assert': identifier not found [D:\a\expected-lite\expected-lite\build\test\expected-lite-cpplatest.t.vcxproj]
```

So adding the header `<cassert>` which declares the `assert` macro should fix the error.