### PR TITLE
Adding [[nodiscard]] to expected<void, E> too

### DIFF
--- a/include/nonstd/expected.hpp
+++ b/include/nonstd/expected.hpp
@@ -2730,7 +2730,7 @@ private:
 /// class expected, void specialization
 
 template< typename E >
-class expected< void, E >
+class nsel_NODISCARD expected< void, E >
 {
 private:
     template< typename, typename > friend class expected;


### PR DESCRIPTION
Currently compilers warn if a regular `expected<T, E>` was ignored, but not the `expected<void, E>` one